### PR TITLE
fix: gitlab release creation

### DIFF
--- a/packages/conventional-gitlab-releaser/src/index.js
+++ b/packages/conventional-gitlab-releaser/src/index.js
@@ -84,7 +84,7 @@ function conventionalGitlabReleaser (auth, changelogOpts, context, gitRawCommits
             }
           }
           debug(`posting %o to the following URL - ${url}`, options)
-        
+
           // Set auth after debug output so that we don't print auth token to console.
           options.token = auth.token
 

--- a/packages/conventional-gitlab-releaser/src/index.js
+++ b/packages/conventional-gitlab-releaser/src/index.js
@@ -73,17 +73,16 @@ function conventionalGitlabReleaser (auth, changelogOpts, context, gitRawCommits
             return
           }
 
-          const url = `projects/${escape(context.owner + `/` + context.repository)}/repository/tags`
+          const url = `projects/${escape(context.owner + `/` + context.repository)}/releases`
           const options = {
             endpoint: auth.url,
             body: {
               tag_name: chunk.keyCommit.version,
               ref: chunk.keyCommit.hash,
-              message: 'Release ' + chunk.keyCommit.version,
-              release_description: chunk.log
+              name: chunk.keyCommit.version,
+              description: chunk.log
             }
           }
-          debug(`posting %o to the following URL - ${url}`, options)
 
           // Set auth after debug output so that we don't print auth token to console.
           options.token = auth.token

--- a/packages/conventional-gitlab-releaser/src/index.js
+++ b/packages/conventional-gitlab-releaser/src/index.js
@@ -83,7 +83,8 @@ function conventionalGitlabReleaser (auth, changelogOpts, context, gitRawCommits
               description: chunk.log
             }
           }
-
+          debug(`posting %o to the following URL - ${url}`, options)
+        
           // Set auth after debug output so that we don't print auth token to console.
           options.token = auth.token
 


### PR DESCRIPTION
Creating release on `repository/tags` endpoint has been deprecated and marked for removal on gitlab.
This causes non-zero exit codes, therefore, breaking automatic CI pipelines.

Fixes #204

ps: I removed the `Release ` prefix, I think it wasn't used previously (it least I haven't seen it in our projects where a couple of hundreds of releases were created by this module).